### PR TITLE
Add toolinfo.json to www/static

### DIFF
--- a/www/static/toolinfo.json
+++ b/www/static/toolinfo.json
@@ -1,0 +1,11 @@
+[
+    {
+      "name" : "video2commons",
+      "title" : "video2commons",
+      "description" : "Transfer video and audio from external sites to Wikimedia Commons",
+      "url" : "https://tools.wmflabs.org/video2commons/",
+      "keywords" : "video, audio, conversion, transfer, webm",
+      "author" : "Zhuyifei1999, Steinsplitter",
+      "repository" : "https://github.com/Toollabs/video2commons"
+    }
+]


### PR DESCRIPTION
Add tool metadata in the toolinfo.json format
to have it indexed in Hay's Tools Directory.
(http://tools.wmflabs.org/hay/directory/)

Closes #17