### PR TITLE
webfrontend: Force https

### DIFF
--- a/video2commons/frontend/app.py
+++ b/video2commons/frontend/app.py
@@ -79,7 +79,8 @@ def force_https():
     """Force user to redirect to https, checking X-Forwarded-Proto."""
     if request.headers.get('X-Forwarded-Proto') == 'http':
         return redirect('https://' + request.headers['Host'] +
-                        request.headers['X-Original-URI'])
+                        request.headers['X-Original-URI'],
+                        code=301)
 
 
 @app.route('/')

--- a/video2commons/frontend/app.py
+++ b/video2commons/frontend/app.py
@@ -74,6 +74,14 @@ def all_exception_handler(e):
         return 500
 
 
+@app.before_request
+def force_https():
+    """Force user to redirect to https, checking X-Forwarded-Proto."""
+    if request.headers.get('X-Forwarded-Proto') == 'http':
+        return redirect('https://' + request.headers['Host'] +
+                        request.headers['X-Original-URI'])
+
+
 @app.route('/')
 def main():
     """Main page."""


### PR DESCRIPTION
Using [X-Forwarded-Proto](https://github.com/wikimedia/operations-puppet/blob/fd210780094b01170ab3df1851db970624eabc5d/modules/dynamicproxy/templates/urlproxy.conf#L135) + an old nginx HSTS configuration in commonsarchive:
```
	# Force https
	if ($http_x_forwarded_proto = "http") {
		return 301 https://$host$request_uri;
	}
	# HSTS
	add_header Strict-Transport-Security "max-age=31536000";
```

Fixes #37