### PR TITLE
urlextract.py: Use webpage_url provided by youtube-dl if available

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -57,7 +57,6 @@ rules:
   no-case-declarations: 2
   no-div-regex: 2
   no-else-return: 0
-  no-empty-label: 2
   no-empty-pattern: 2
   no-eq-null: 2
   no-eval: 2

--- a/video2commons/frontend/urlextract.py
+++ b/video2commons/frontend/urlextract.py
@@ -44,6 +44,7 @@ def do_extract_url(url):
 
     ie_key = info['extractor_key']
     title = info.get('title', '').strip()
+    url = info.get('webpage_url') or url
 
     filedesc = """
 =={{int:filedesc}}==


### PR DESCRIPTION
As the short form of youtu.be is spam-blacklisted.