### PR TITLE
Convert call with keyword argument to spread dict

### DIFF
--- a/video2commons/backend/upload/__init__.py
+++ b/video2commons/backend/upload/__init__.py
@@ -86,10 +86,14 @@ def upload_pwb(
 
     statuscallback('Uploading...', -1)
     try:
-        if not site.upload(
-            page, source_filename=filename, comment=comment, text=filedesc,
-            chunk_size=chunked, async=bool(chunked)  # , ignore_warnings=['exists-normalized']
-        ):
+        if not site.upload(page, **{
+            'source_filename': filename,
+            'comment': comment,
+            'text': filedesc,
+            'chunk_size': chunked,
+            'async': bool(chunked),
+            # 'ignore_warnings': ['exists-normalized'],
+        }):
             errorcallback('Upload failed!')
     except pywikibot.data.api.APIError:
         # recheck


### PR DESCRIPTION
async is a keyword now, so we need this workaround to avoid a syntax error.