### PR TITLE
T407375: Set healthcheck workarround with cron

### DIFF
--- a/puppet/backend.pp
+++ b/puppet/backend.pp
@@ -280,3 +280,10 @@ cron::job { 'v2ccleanup':
     minute  => '48',
     require => Service['v2ccelery'],
 }
+cron::job { 'v2chealthcheck':
+    command => '/bin/sh /srv/v2c/video2commons/utils/healthcheck.sh',
+    user    => 'tools.video2commons',
+    minute  => '1/5',
+    require => Service['v2ccelery'],
+}
+

--- a/utils/healthcheck.sh
+++ b/utils/healthcheck.sh
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+WORKERS_RUNNING=$(/srv/v2c/venv/bin/python3 -m celery -A video2commons.backend.worker inspect ping -j |jq 'with_entries(select(.key | test ("celery[12]@'"$HOSTNAME"'"))) | length == 2')
+
+if [ "$WORKERS_RUNNING" = "true" ]; then
+    exit 0
+else
+    systemctl restart v2ccelery.service
+    exit 1
+fi


### PR DESCRIPTION
It would be better to have it integrated into the code with a heartbeat and do some tracing to figure out why the workers are hanging, but this should get the workers back to working.