### PR TITLE
Adjust VP9 quality to lower output size

### DIFF
--- a/video2commons/backend/encode/transcode.py
+++ b/video2commons/backend/encode/transcode.py
@@ -86,7 +86,7 @@ class WebVideoTranscode:
         # WebM VP9 transcode:
         'vp9.webm':
             {
-                'crf': 20,
+                'crf': 35,
                 'videoBitrate': '0',
                 'audioBitrate': '128',
                 'samplerate': '48000',
@@ -96,11 +96,13 @@ class WebVideoTranscode:
                 'videoCodec': 'vp9',
                 'audioCodec': 'opus',
                 'tileColumns': '4',
+                'speed': '2',
+                'quality': 'good',
                 'type': 'video/webm codecs="vp9, opus"',
             },
         'an.vp9.webm':
             {
-                'crf': 20,
+                'crf': 35,
                 'videoBitrate': '0',
                 'noUpscaling': 'True',
                 'twopass': 'True',
@@ -108,6 +110,8 @@ class WebVideoTranscode:
                 'videoCodec': 'vp9',
                 'noaudio': 'True',
                 'tileColumns': '4',
+                'speed': '2',
+                'quality': 'good',
                 'type': 'video/webm codecs="vp9, opus"',
             },
 

--- a/video2commons/backend/encode/transcodejob.py
+++ b/video2commons/backend/encode/transcodejob.py
@@ -348,6 +348,10 @@ class WebVideoTranscodeJob(object):
         elif 'speed' in options:
             cmd += ' -speed ' + escape_shellarg(options['speed'])
 
+        # In libvpx quality sets a deadline on how long frames can be processed.
+        if 'quality' in options:
+            cmd += ' -quality ' + escape_shellarg(options['quality'])
+
         # Output WebM
         cmd += " -f webm"
 


### PR DESCRIPTION
This patch addresses an issue encountered in issue #210.

The current `ffmpeg` settings are bloating the size of input videos with small bitrates, resulting in output files being much larger than the originals in some cases. In one case, this has caused a 1.5GB file to result in a >10GB output, causing a `SIGXFSZ` (File size limit exceeded) error in the worker due to ulimit restrictions imposed on the `ffmpeg` process.

This patch tweaks some settings that should help avoid this problem when uploading longer videos potentially at the cost of quality, though the quality in the example video in the issue didn't appear to be affected. The new settings work best for 1080p video at 30-60 FPS and are loosely based on [recommendations offered by Google](https://developers.google.com/media/vp9/settings/vod).

**What:**

* (VP9) CRF has been increased from 20 to 35 to reduce output file size.
* (VP9) Quality has been changed to 'good' (default is 'best') to speed up encoding time.
* (VP9) Speed has been increased to from '1' to '2' for the 2nd pass to speed up encoding time.

**Why:**

* Our current CRF of 20 results in a quality too high for video uploaded to the web (for 1080p). 31-35 is a good range for 1080p content at 30-60 FPS. A lower CRF makes more sense for 2k and 4k video, but we don't currently have a way to adjust options for different resolutions.
* The default quality of 'best' used by `libvpx` substantially slows down encoding time for complex frames in order to achieve better compression. `good` offers a good balance between speed and quality.
* Speed (for the 2nd pass only) was adjusted for the same reason as quality.