### PR TITLE
Updated the filename check to permit <= 228 bytes

### DIFF
--- a/video2commons/frontend/urlextract.py
+++ b/video2commons/frontend/urlextract.py
@@ -53,6 +53,13 @@ FILEDESC_TEMPLATE = """
 [[Category:Uploaded with video2commons]]
 """
 
+# Upload filenames are limited to 228 bytes (not counting the extension).
+#
+# This number was chosen since the length of the longest output extension we
+# support is 12 bytes long, and 228 + 12 = 240, which is the maximum filename
+# size supported by MediaWiki for uploads.
+MAX_FILENAME_SIZE = 228
+
 
 def make_dummy_desc(filename):
     filedesc = FILEDESC_TEMPLATE % {
@@ -339,7 +346,8 @@ def sanitize(filename):
 
 def do_validate_filename(filename):
     """Validate filename for invalid characters/parts."""
-    assert len(filename) < 250, 'Your filename is too long'
+    assert len(filename.encode('utf-8')) <= MAX_FILENAME_SIZE, \
+        'Your filename is too long'
 
     for rule in sanitationRules:
         reobj = rule['pattern'].search(filename)


### PR DESCRIPTION
This patch resolves issue https://github.com/toolforge/video2commons/issues/213.

When we perform uploads to Commons we check filenames to make sure they are under 250 characters, however this doesn't work for a couple of reasons. First, there is a maximum size of 240 bytes for filenames when uploading to Commons. Second, individual UTF-8 characters can be multiple bytes long, and since we check character length and not byte size, our validation permits invalid names that cause the upload to fail.

This patch edits the validation function to check the byte size of filenames rather than the character length. Also, the size has been adjusted to 228 bytes to both fit under the limit imposed by Commons and to accommodate for long filename extensions. The maximum extension size of outputs from V2C is 12 bytes. Because of this, 228 is the largest amount of bytes we can support for output filenames to be considered valid.