### PR TITLE
Add AV1 encoding support

### DIFF
--- a/video2commons/backend/encode/globals.py
+++ b/video2commons/backend/encode/globals.py
@@ -26,9 +26,16 @@ background_priority = 19
 
 # The total amout of time a transcoding shell command can take:
 background_time_limit = 3600 * 24 * 2  # 2 days
+
 # Maximum amount of virtual memory available to transcoding processes in KB
-# 2GB avconv
-background_memory_limit = 8 * 1024 * 1024  # 8GB
+#
+# At least 12GB VIRT is needed for libsvtav1 encoding to prevent segfaults.
+# 1080p videos of any significant length and 4k video will result in VIRT
+# allocations larger than this, so some padding is needed. libsvtav1 with lots
+# of threads is very aggressive with virtual memory allocation and only uses
+# ~25-30% of what it actually allocates per worker (max ~8GB).
+background_memory_limit = 32 * 1024 * 1024  # 32GB
+
 # Maximum file size transcoding processes can create, in KB
 background_size_limit = 10 * 1024 * 1024  # 10GB
 # Number of threads to use in avconv for transcoding

--- a/video2commons/backend/encode/transcode.py
+++ b/video2commons/backend/encode/transcode.py
@@ -115,6 +115,33 @@ class WebVideoTranscode:
                 'type': 'video/webm codecs="vp9, opus"',
             },
 
+        # WebM AV1 transcode:
+        #
+        # Presets: https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Docs/CommonQuestions.md#what-presets-do
+        # Multipass: https://github.com/HandBrake/HandBrake/issues/4831#issuecomment-1546617210
+        'av1.webm':
+            {
+                'audioBitrate': '128',
+                'audioCodec': 'opus',
+                'crf': 30,
+                'preset': '6',
+                'samplerate': '48000',
+                'twopass': 'False', # twopass is not supported for AV1 with CRF
+                'type': 'video/webm codecs="av01, opus"',
+                'videoBitrate': '0',
+                'videoCodec': 'av1',
+            },
+        'an.av1.webm':
+            {
+                'crf': 30,
+                'noaudio': 'True',
+                'preset': '6',
+                'twopass': 'False', # twopass is not supported for AV1 with CRF
+                'type': 'video/webm codecs="av01, opus"',
+                'videoBitrate': '0',
+                'videoCodec': 'av1',
+            },
+
         # Audio profiles
         'ogg':
             {

--- a/video2commons/frontend/api.py
+++ b/video2commons/frontend/api.py
@@ -290,12 +290,12 @@ def list_formats():
     if video:
         if audio:
             formats = ['ogv (Theora/Vorbis)', 'webm (VP8/Vorbis)',
-                       'webm (VP9/Opus)']
-            prefer = 'webm (VP9/Opus)'
+                       'webm (VP9/Opus)', 'webm (AV1/Opus)']
+            prefer = 'webm (AV1/Opus)'
         else:
             formats = ['ogv (Theora)', 'webm (VP8)',
-                       'webm (VP9)']
-            prefer = 'webm (VP9)'
+                       'webm (VP9)', 'webm (AV1)']
+            prefer = 'webm (AV1)'
     else:
         if audio:
             formats = ['ogg (Vorbis)', 'opus (Opus)']
@@ -366,6 +366,8 @@ def get_backend_keys(format):
             (VIDEO_FMT.format(vcodec='vp8', vext='webm'), 'an.webm'),
         'webm (VP9)':
             (VIDEO_FMT.format(vcodec='vp9', vext='webm'), 'an.vp9.webm'),
+        'webm (AV1)':
+            (VIDEO_FMT.format(vcodec='av1', vext='webm'), 'an.av1.webm'),
         'ogg (Vorbis)':
             (AUDIO_FMT.format(acodec='vorbis', aext='ogg'), 'ogg'),
         'opus (Opus)':
@@ -382,6 +384,10 @@ def get_backend_keys(format):
             (COMBINED_FMT.format(
                 vcodec='vp9', vext='webm', acodec='opus', aext='webm'),
              'vp9.webm'),
+        'webm (AV1/Opus)':
+            (COMBINED_FMT.format(
+                vcodec='av1', vext='webm', acodec='opus', aext='webm'),
+             'av1.webm'),
     }[format]
 
 


### PR DESCRIPTION
Resolves #244 

This patch adds AV1 encoding support using `libsvtav1` to V2C. It's useful support AV1 as it's a free codec that's becoming more widely used, encoding is fast, and quality is great, so there's no point in transcoding AV1 videos passed into V2C to VP9 before uploading them to Commons.

**Changes**:

* Add AV1 support for files being input to V2C
* Transcode to AV1 by default for non-free codecs

**Notes**:

`background_memory_limit` in `globals.py` had to be increased in order for `libsvtav1` to work. `libsvtav1` is very aggressive with virtual memory allocations, and will segfault if restricted too much. In my tests I've found that `libsvtav1` will allocate ~12GB for 1080p video and will peak out at 21GB for 4k.

It's worth noting that this is just virtual memory (VIRT) and not actual memory usage (RES). While doing 4k transcodes I've not seen the `ffmpeg` process exceed 8GB with 10 threads. Memory usage will increase with the amount of threads being used. If we want to set a hard cap on the maximum memory used by worker processes then we should consider using cgroups instead (setup is a bit more complicated than ulimit).