### PR TITLE
Add metadata flags to transcode jobs

### DIFF
--- a/video2commons/backend/encode/__init__.py
+++ b/video2commons/backend/encode/__init__.py
@@ -45,7 +45,7 @@ def encode(source, origkey, statuscallback=None, errorcallback=None):
 
     target = source + '.' + key
     job = WebVideoTranscodeJob(
-        source, target, key, preserve, statuscallback, errorcallback
+        source, target, key, preserve, statuscallback, errorcallback, info
     )
 
     return target if job.run() else None

--- a/video2commons/backend/encode/transcodejob.py
+++ b/video2commons/backend/encode/transcodejob.py
@@ -48,7 +48,7 @@ class WebVideoTranscodeJob(object):
 
     def __init__(
         self, source, target, key, preserve={},
-        statuscallback=None, errorcallback=None
+        statuscallback=None, errorcallback=None, source_info=None
     ):
         """Initialize the instance."""
         self.source = os.path.abspath(source)
@@ -59,6 +59,7 @@ class WebVideoTranscodeJob(object):
         self.statuscallback = statuscallback or (lambda text, percent: None)
         self.errorcallback = errorcallback or (lambda text: None)
         self.removeDuplicates = True
+        self.source_info = source_info
 
     def output(self, msg):
         """
@@ -213,6 +214,13 @@ class WebVideoTranscodeJob(object):
 
         if 'vpre' in options:
             cmd += ' -vpre ' + escape_shellarg(options['vpre'])
+
+        # Copy non-standard custom metadata specific to mp4 and mov files
+        container = self.source_info.format.format
+        if container == 'mov,mp4,m4a,3gp,3g2,mj2':
+            cmd += ' -movflags use_metadata_tags'
+
+        cmd += ' -map_metadata 0'
 
         if 'novideo' in options:
             cmd += " -vn "


### PR DESCRIPTION
This patch attempts to fix [T284970](https://phabricator.wikimedia.org/T284970).

I've added explicit metadata flags to ffmpeg for transcode jobs. In my tests I saw metadata was being transferred even without these flags when remuxing mp4 -> webm, so I'm unsure how effective this will be. There isn't enough information in the ticket as the example source file links are now broken.

**Changes**:

* Add `-movflags use_metadata_tags` to the `ffmpeg` call when the source video is an mp4 (or similar) format
* Add `-map_metadata 0` to the `ffmpeg` call for all transcodes