### PR TITLE
Disable worker prefetch with worker_prefetch_multiplier=1

### DIFF
--- a/video2commons/backend/worker.py
+++ b/video2commons/backend/worker.py
@@ -47,6 +47,7 @@ app = celery.Celery(
 app.conf.result_expires = 30 * 24 * 3600  # 1 month
 
 app.conf.accept_content = ['json']
+app.conf.worker_prefetch_multiplier = 1
 
 redisconnection = Redis(host=redis_host, db=3, password=redis_pw)
 


### PR DESCRIPTION
### Description

Relevant ticket: https://phabricator.wikimedia.org/T407375#11402549

Changing this config value should prevent a single worker from picking up more transcoding jobs than it can handle at the present time. The default value of 4 can lead to a situation where workers are sitting idle that could otherwise be processing videos, and is the likely reason why we have some workers sitting idle while other workers are hoarding tasks that can't be processed yet.

### Changes

* Set `app.conf.worker_prefetch_multiplier` to `1` in `worker.py`

### Relevant Documentation

* https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-prefetch-multiplier