### PR TITLE
Divide thread allocation by max concucurrent jobs

### DIFF
--- a/video2commons/backend/encode/__init__.py
+++ b/video2commons/backend/encode/__init__.py
@@ -25,7 +25,7 @@ from .globals import ffmpeg_location, ffprobe_location
 from converter import Converter
 
 
-def encode(source, origkey, statuscallback=None, errorcallback=None):
+def encode(source, origkey, statuscallback=None, errorcallback=None, concurrency=None):
     """Main encode function."""
     source = os.path.abspath(source)
     preserve = {'video': False, 'audio': False}
@@ -45,7 +45,8 @@ def encode(source, origkey, statuscallback=None, errorcallback=None):
 
     target = source + '.' + key
     job = WebVideoTranscodeJob(
-        source, target, key, preserve, statuscallback, errorcallback, info
+        source, target, key, preserve, statuscallback, errorcallback, info,
+        concurrency,
     )
 
     return target if job.run() else None


### PR DESCRIPTION
## Description

When transcoding videos to AV1 with `libsvtav1` the library will use a thread count equal to the number of CPU cores that we have. We also specify this number to the `-threads` parameter, although `ffmpeg` ignores that value for AV1. Since we have multiple concurrent workers per node this results in an excess of threads being allocated that compete for CPU resources. This also increases the amount of memory required and has been resulting in frequent OOM errors.

This patch sets `-svtav1-params lp=<threads>` to the number of cores divided by the number of concurrent workers on our individual worker nodes (currently 3). This should lessen the amount of memory allocated and allow more tasks to execute concurrently. It is worth noting that a worker processing a single job may not process that job as quickly as before, but if the worker is at max capacity there should be no difference.

## Changes

* Set `-svtav1-params lp=<threads>` and `-threads <threads>` where `<threads>` is the number of cores divided by worker threads
  * This value is clamped between `1` and the number of CPU cores
  * The value we pass to `--concurrency` is parsed from the `CELERYD_OPTS` environment variable since Celery doesn't offer direct access to this value at runtime when it's passed via CLI parameters