### PR TITLE
Fix yt-dlp JavaScript runtime by installing deno

### DIFF
--- a/puppet/README.md
+++ b/puppet/README.md
@@ -1,0 +1,11 @@
+# Puppet Configuration
+
+This directory contains the Puppet manifest for the video2commons worker backend.
+
+## Required Modules
+
+The following Puppet modules are required:
+
+* [puppet/cron](https://forge.puppet.com/modules/puppet/cron)
+* [puppet/nodejs](https://forge.puppet.com/modules/puppet/nodejs)
+* [puppetlabs/apt](https://forge.puppet.com/modules/puppetlabs/apt)

--- a/puppet/backend.pp
+++ b/puppet/backend.pp
@@ -10,6 +10,16 @@ $http_host = 'v2c.wmflabs.org'
 
 include cron
 
+class { 'nodejs':
+    repo_version => '24',
+}
+
+# Needed for yt-dlp as it uses JavaScript to get higher quality videos.
+package { 'deno':
+  ensure   => installed,
+  provider => 'npm',
+}
+
 package { [
     'build-essential',
     'python3-dev',


### PR DESCRIPTION
## Description

As of yt-dlp version [2025.11.12](https://github.com/yt-dlp/yt-dlp/releases/tag/2025.11.12) an external JavaScript runtime is now required for full YouTube support. We have been having occasional issues with videos being downloaded in a lower resolution than was available, at least since October. Missing the JS runtime is a likely cause of this and the problem will only get worse with time.

yt-dlp recommends that `deno` is used as the JavaScript runtime. `deno` can be installed with `npm` or via a shell script. I opted for the former approach since that would allow for a declarative and idempotent way of ensuring `deno` is present. `node` can be used with an option override, but only the CLI option for this is documented and I couldn't find any code examples of anyone doing this. The yt-dlp team recommends against using `node` instead of `deno` if at all possible.

## Changes

* Install `node` v24 LTS and `npm` from the NodeSource Debian repository
  * The version of `node` in the base Debian repository is v18 and cannot be used since it is no longer supported and the installation of `deno` with an unsupported version could potentially break in the near future
* Use `npm` and the `puppet/nodejs` module to install `deno` using `npm`

## Deployment

There are a couple of new puppet modules that need to be installed for the manifest to apply successfully. There is no `Puppetfile` in this repository for me to add modules in, so I assume that has to be done some other way.

These are the modules that need to be added:

* [puppet/nodejs](https://forge.puppet.com/modules/puppet/nodejs)
  * `puppet/nodejs` is needed to install node and npm, which is needed to install deno
* [puppetlabs/apt](https://forge.puppet.com/modules/puppetlabs/apt)
  * `puppetlabs/apt` is an indirect dependency of `puppet/nodejs` that's needed to add a new apt repository

## Confirmation

You can confirm the runtime is being detected by running the following command on the instances:

```
yt-dlp -v
```

If you see `[debug] JS runtimes: deno-2.6.4` in the output (or any other version) then it's setup correctly. I tested this in a Debian Bookworm container and it picked it up as expected for me.