### PR TITLE
Add non-blocking deployment script

### DIFF
--- a/utils/deploy.sh
+++ b/utils/deploy.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+encoder_hosts=$(cat <<EOF
+encoding01.video.eqiad1.wikimedia.cloud
+encoding02.video.eqiad1.wikimedia.cloud
+encoding03.video.eqiad1.wikimedia.cloud
+encoding04.video.eqiad1.wikimedia.cloud
+encoding05.video.eqiad1.wikimedia.cloud
+encoding06.video.eqiad1.wikimedia.cloud
+EOF
+)
+
+bastion_host=login.toolforge.org
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+backend_pp="$script_dir/../puppet/backend.pp"
+
+if [ ! -f "$backend_pp" ]; then
+    echo "Error: Puppet manifest not found at '$backend_pp'" >&2
+    exit 1
+elif [ -z "$V2C_USERNAME" ]; then
+    echo "Error: V2C_USERNAME environment variable is not set" >&2
+    exit 1
+elif [ -z "$V2C_CONSUMER_KEY" ]; then
+    echo "Error: V2C_CONSUMER_KEY environment variable is not set" >&2
+    exit 1
+elif [ -z "$V2C_CONSUMER_SECRET" ]; then
+    echo "Error: V2C_CONSUMER_SECRET environment variable is not set" >&2
+    exit 1
+elif [ -z "$V2C_REDIS_PW" ]; then
+    echo "Error: V2C_REDIS_PW environment variable is not set" >&2
+    exit 1
+fi
+
+# Patch the puppet manifest to include secrets that aren't in the repository.
+# The values being substituted in are alphanumeric and are safe to use. Convert
+# the manifest to base64 as well to prevent escaping issues when stuffing it
+# into the script.
+patched_manifest=$(sed -E "
+    s/^\\\$consumer_key[[:space:]]*=[[:space:]]*'REDACTED'/\\\$consumer_key = '$V2C_CONSUMER_KEY'/
+    s/^\\\$consumer_secret[[:space:]]*=[[:space:]]*'REDACTED'/\\\$consumer_secret = '$V2C_CONSUMER_SECRET'/
+    s/^\\\$redis_pw[[:space:]]*=[[:space:]]*'REDACTED'/\\\$redis_pw = '$V2C_REDIS_PW'/
+    " "$backend_pp" | base64)
+
+# Create the script to be run on the remote hosts that drops the manifest into
+# /tmp, runs the apply script, and reloads the service.
+apply_script=$(cat <<EOF
+echo -n "$patched_manifest" | base64 -d > /tmp/backend.pp
+
+sudo puppet apply /tmp/backend.pp --debug
+
+if [ \$? -ne 0 ]; then
+    rm /tmp/backend.pp
+    exit 1
+else
+    rm /tmp/backend.pp
+fi
+EOF
+)
+
+while read -r encoder_host; do
+    echo "Applying puppet manifest to '$encoder_host' and restarting v2c service..."
+
+    ssh -J "$V2C_USERNAME@$bastion_host" "$V2C_USERNAME@$encoder_host" 'bash -s' <<< "$apply_script"
+
+    if [ $? -ne 0 ]; then
+        echo "Failed to apply puppet manifest to '$encoder_host'" >&2
+    else
+        echo "Puppet manifest applied to '$encoder_host'"
+    fi
+done <<< "$encoder_hosts"
+
+echo "Done"


### PR DESCRIPTION
## Description

This patch adds a script as described in [my comment in T410730](https://phabricator.wikimedia.org/T410730#11530540) that can assist with deployment. I've left out GitHub Actions integration for now, but I can add that later if we think it's a good idea.

~~@don-vip I haven't tested this script against the encoders. However, I did test most of it against another machine on my network with the exception of [lines 50-58](https://github.com/toolforge/video2commons/blob/e7ad69e33530a91bb550a8e671d0612bb0e9e0e9/utils/deploy.sh#L50-L58) of `deploy.sh`. If you're okay with me testing it or you want to do it, please let me know. If we can test this against a real encoder instance I would feel more comfortable taking this PR out of draft status.~~

**Update**: I've tested this against `encoding01` and `encoding02` after making some fixes and it appears to be working the way I expect.

## Configuration

This script relies heavily on environment variables since that would make it easier to work with in a CI/CD workflow if/when we implement something like that.

* `V2C_USERNAME`: The ssh username to use when connecting to the encoder
* `V2C_CONSUMER_KEY`: Value that gets substituted into the puppet manifest
* `V2C_CONSUMER_SECRET`: Value that gets substituted into the puppet manifest
* `V2C_REDIS_PW`: Value that gets substituted into the puppet manifest

## Changes

* Add new `deploy.sh` Bash script to assist with deployments