### PR TITLE
Extract subtitles from video containers

### DIFF
--- a/video2commons/backend/requirements.txt
+++ b/video2commons/backend/requirements.txt
@@ -3,6 +3,7 @@ celery[redis]
 langcodes
 chardet
 mwoauth>=0.2.4,!=0.3.1
+language_data>=1.4.0,<2
 #pywikibot
 mwparserfromhell>=0.5.2
 PythonVideoConverter


### PR DESCRIPTION
## Description

Resolves #45 

Currently any videos with subtitles embedded within the video container itself, such as mkv files, do not have their subtitles uploaded when requested. We should import these subtitles. This patch modifies the worker so that it attempts the extraction of subtitles from the video container, and if present, uploads them.

## Changes

* Probe videos for subtitles if they're not detected by yt-dlp and upload them if present.
* Move the subtitle upload code into a separate function shared by both primary subtitle functions.
* Add the `language_data` package to `backend/requirements.txt` to convert language codes to human-readable descriptions for status updates back to the user.