### PR TITLE
Hotfix: Update Redis URL to the new one

### DIFF
--- a/puppet/backend.pp
+++ b/puppet/backend.pp
@@ -1,7 +1,7 @@
 $consumer_key = 'REDACTED'
 $consumer_secret = 'REDACTED'
 $redis_pw = 'REDACTED'
-$redis_host = 'video-redis-buster.video.eqiad1.wikimedia.cloud'
+$redis_host = 'video-redis-bookworm.video.eqiad1.wikimedia.cloud'
 $http_host = 'v2c.wmflabs.org'
 
 # Configure encoding05 and encoding06 to use 1 worker and listen to the heavy


### PR DESCRIPTION
Turns out our puppet manifest that was committed to the repo has had the old outdated URL for Redis in it and applying it results in workers failing to connect. This patch fixes that. I already manually fixed the configuration in the workers when I noticed no tasks were being processed and they're working again.