### PR TITLE
Only specify cookiefile if cookies exist

### DIFF
--- a/video2commons/backend/download/__init__.py
+++ b/video2commons/backend/download/__init__.py
@@ -24,8 +24,8 @@ from celery.utils.log import get_logger
 import yt_dlp
 from yt_dlp.utils import std_headers, DownloadError
 
-from video2commons.config import tooldir, youtube_user, youtube_pass
 from video2commons.exceptions import TaskError
+from video2commons.shared.yt_dlp import add_youtube_params
 
 
 def download(
@@ -78,13 +78,7 @@ def download(
         std_headers["User-Agent"] = ""
         # https://github.com/yt-dlp/yt-dlp/wiki/Extractors#exporting-youtube-cookies
         # https://github.com/yt-dlp/yt-dlp/wiki/FAQ#how-do-i-pass-cookies-to-yt-dlp
-        params.update(
-            {
-                "cookiefile": tooldir + "/../cookies.txt",
-                "username": youtube_user,
-                "password": youtube_pass,
-            }
-        )
+        params = add_youtube_params(params)
 
     last_percentage = [Ellipsis]
 

--- a/video2commons/frontend/urlextract.py
+++ b/video2commons/frontend/urlextract.py
@@ -21,7 +21,6 @@
 
 from collections import OrderedDict
 from video2commons.backend.encode.transcode import WebVideoTranscode
-from video2commons.config import tooldir, youtube_user, youtube_pass
 
 import json
 import re
@@ -31,6 +30,7 @@ import guess_language
 import pywikibot
 import yt_dlp
 
+from video2commons.shared.yt_dlp import add_youtube_params
 from video2commons.frontend.wcqs import WcqsSession
 
 SITE = pywikibot.Site()
@@ -178,13 +178,7 @@ def do_extract_url(url):
     if ".youtube.com/" in url:
         # https://github.com/yt-dlp/yt-dlp/wiki/Extractors#exporting-youtube-cookies
         # https://github.com/yt-dlp/yt-dlp/wiki/FAQ#how-do-i-pass-cookies-to-yt-dlp
-        params.update(
-            {
-                "cookiefile": tooldir + "/../cookies.txt",
-                "username": youtube_user,
-                "password": youtube_pass,
-            }
-        )
+        params = add_youtube_params(params)
     with yt_dlp.YoutubeDL(params) as dl:
         info = dl.extract_info(url, download=False)
 

--- a/video2commons/shared/yt_dlp.py
+++ b/video2commons/shared/yt_dlp.py
@@ -1,0 +1,29 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>
+
+"""Shared yt-dlp helpers used by both the worker app and the flask app."""
+
+import os
+
+from video2commons.config import tooldir
+
+
+def add_youtube_params(params):
+    """Adds YouTube authentication parameters to yt-dlp request params."""
+    params = params.copy()
+
+    cookies_path = tooldir + "/../cookies.txt"
+    if os.path.isfile(cookies_path):
+        params["cookiefile"] = cookies_path
+
+    return params


### PR DESCRIPTION
## Description

This patch adds a file check that fixes an issue where if the cookie file is not present and in a restricted directory with no write permissions, yt-dlp will fail. This happens because yt-dlp updates the cookie file whenever making YouTube requests. This change allows cookies to be optional without throwing permissions errors.

This patch is one part of trying to fix #308, which I suspect is happening because of stale session cookies. Keeping the session valid for a long duration of time for the purpose of downloading age restricted content is currently infeasible, so the cookies haven't been kept up to date. Loading stale cookies provides no benefit.

## Changes

* Only specify `cookiefile` in yt-dlp params if one exists.
* Do not pass `username` and `password` to yt-dlp as it's currently unsupported (we didn't do this anyway).