### PR TITLE
Apply --no-block to start and stop commands

### DIFF
--- a/puppet/backend.pp
+++ b/puppet/backend.pp
@@ -270,6 +270,8 @@ service { 'v2ccelery':
     ensure  => running,
     enable  => true,
     require => Package['ffmpeg'],
+    start   => '/usr/bin/systemctl --no-block start v2ccelery.service',
+    stop    => '/usr/bin/systemctl --no-block stop v2ccelery.service',
     restart => '/usr/bin/systemctl --no-block restart v2ccelery.service',
 }
 


### PR DESCRIPTION
If a restart is already in progress then Puppet will try to call start instead when applying the manifest. Calling start while a restart is already in progress should be ignored by systemd, however since we only specify `--no-block` for restart and not start this results in puppet hanging waiting for jobs to complete.

This patch adds `--no-block` to the other service commands to prevent that, which prevents encoder deployments from hanging if a previous one hasn't fully been applied yet.