### PR TITLE
Make "Import Audio" and "Import Video" act like suggestions

### DIFF
--- a/video2commons/backend/encode/helpers.py
+++ b/video2commons/backend/encode/helpers.py
@@ -1,0 +1,30 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>
+
+"""Helper function for the encode module."""
+
+
+def get_video(info):
+    """Returns the first video stream from a MediaInfo object.
+
+    This exists to workaround a bug with the Converter library where the video
+    property will erroneously select audio streams for some videos.
+    """
+    if not info:
+        return None
+
+    for stream in info.streams:
+        if stream.type == "video":
+            return stream
+
+    return None

--- a/video2commons/backend/encode/transcodejob.py
+++ b/video2commons/backend/encode/transcodejob.py
@@ -33,6 +33,7 @@ import math
 import time
 import subprocess
 import signal
+
 from .transcode import WebVideoTranscode
 from .globals import (
     background_priority,
@@ -44,6 +45,7 @@ from .globals import (
     time_to_seconds,
     av1_max_threads_4k,
 )
+from .helpers import get_video
 
 from video2commons.exceptions import TaskAbort
 
@@ -325,11 +327,9 @@ class WebVideoTranscodeJob(object):
 
         # Workaround: Limit the number of threads for 4k (and higher) video for
         # AV1 transcoding due to limited memory on the workers.
-        if self.source_info and self.source_info.video:
-            width = self.source_info.video.video_width
-            height = self.source_info.video.video_height
-
-            if width >= 3840 or height >= 2160:
+        video = get_video(self.source_info)
+        if video:
+            if video.video_width >= 3840 or video.video_height >= 2160:
                 threads = min(threads, av1_max_threads_4k)
 
         cmd = " -threads " + str(threads)


### PR DESCRIPTION
## Description

Resolves #64 

This patch makes so workers that encounter a video with a missing audio track no longer error out. The same goes for the reverse as well now when processing audio files.

Also included in this patch is a workaround for a bug I encountered that affects the [converter](https://github.com/senko/python-video-converter) library that we use to probe input files. This bug causes the `video` property of `MediaInfo` objects to return an audio stream instead of the expected video stream. It's possible this is what may be causing #266, but I need to do more testing. Regardless, this needed to be fixed for this patch to work.

## Changes

* Gracefully handle missing audio and video streams for videos regardless of task preference.
* Fixed an issue with video info handling that affected only some videos.