### PR TITLE
Update Flickr CC license for new uploads

### DIFF
--- a/video2commons/frontend/urlextract.py
+++ b/video2commons/frontend/urlextract.py
@@ -304,9 +304,12 @@ def _license(url, ie_key, title, info):
             return "{{YouTube CC-BY%s}}" % uploader_param
         return "{{YouTube CC-BY 4.0%s}}" % uploader_param
     elif ie_key == "Flickr":
+        # https://blog.flickr.net/en/2025/06/18/creative-commons-4-0-has-arrived-on-flickr/
+        version = "2.0" if _date(url, ie_key, title, info) <= "2025-06-18" else "4.0"
+
         return {
-            "Attribution": "{{cc-by-2.0%s}}" % uploader_param,
-            "Attribution-ShareAlike": "{{cc-by-sa-2.0%s}}" % uploader_param,
+            "Attribution": "{{cc-by-%s%s}}" % (version, uploader_param),
+            "Attribution-ShareAlike": "{{cc-by-sa-%s%s}}" % (version, uploader_param),
             "No known copyright restrictions": "{{Flickr-no known copyright restrictions}}",
             "United States government work": "{{PD-USGov}}",
             "Public Domain Dedication (CC0)": "{{cc-zero}}",


### PR DESCRIPTION
As of June 18th 2025 CC BY content on Flickr now uses a CC BY 4.0 license instead of the previous CC By 2.0 license. See the [announcement](https://blog.flickr.net/en/2025/06/18/creative-commons-4-0-has-arrived-on-flickr/) on the Flickr blog for more details. This patch modifies the license checker to use 2.0 for content prior to this date and the new 4.0 license for everything after (similar to the YouTube license check).