### PR TITLE
Hotfix: Bypass ffprobe for now

### DIFF
--- a/video2commons/frontend/api.py
+++ b/video2commons/frontend/api.py
@@ -46,7 +46,6 @@ from video2commons.frontend.urlextract import (
     do_validate_filename,
     do_validate_filedesc,
     sanitize,
-    predict_task_type_ffprobe,
     DEFAULT_QUEUE,
     HEAVY_QUEUE,
 )
@@ -452,8 +451,12 @@ def run_task():
             if not FILEKEY_REGEX.match(filekey):
                 return jsonify(error="Invalid file key format"), 400
 
-            filepath = os.path.join(UPLOADS_DIR, filekey)
-            queue = predict_task_type_ffprobe(filepath)
+            # Hotfix: Temporarily default to DEFAULT_QUEUE until the ffprobe
+            # issue is properly fixed.
+            queue = DEFAULT_QUEUE
+
+            # filepath = os.path.join(UPLOADS_DIR, filekey)
+            # queue = predict_task_type_ffprobe(filepath)
         else:
             queue = DEFAULT_QUEUE
 


### PR DESCRIPTION
It looks like ffprobe isn't available in the production toolforge environment to analyze files, and the gentoo prefix isn't available there. We'll have to go about this in a different way for manual uploads unfortunately. In the meantime this patch routes manual uploads to the default queue. If they fail then they will get moved over to the heavy queue if a restart is initiated.

I'm going to check if it's technically feasible for workers to decide to re-queue/re-prioritize tasks that they are unable to consume due to resource constraints as they have access to ffprobe in their environment.

Relevant issue: #315