### PR TITLE
Add username to interface in logout link

### DIFF
--- a/video2commons/frontend/app.py
+++ b/video2commons/frontend/app.py
@@ -101,6 +101,7 @@ def all_exception_handler(e):
             html_message=message,
             stacktrace=stacktrace,
             loggedin=loggedin,
+            username=session.get("username"),
         ), 500
     except:
         return message, 500
@@ -142,7 +143,7 @@ def main():
         app.session_interface.abandon_session(app, session)
         return render_template("main.min.html", loggedin=False)
 
-    return render_template("main.min.html", loggedin=True)
+    return render_template("main.min.html", loggedin=True, username=session["username"])
 
 
 def dologin():
@@ -242,6 +243,7 @@ def logincallback():
             message="You must be an autoconfirmed Commons user "
             "with at least 50 edits to use this tool.",
             loggedin=True,
+            username=identify["username"],
         )
 
     session["access_token_key"], session["access_token_secret"] = (

--- a/video2commons/frontend/templates/base.html
+++ b/video2commons/frontend/templates/base.html
@@ -130,7 +130,7 @@
         <ul class="nav navbar-nav navbar-{% if lang() is rtl %}left{% else %}right{% endif %}">
           <li><a href="https://commons.wikimedia.org/w/index.php?title=Special:MyLanguage/Commons:Video2commons&amp;uselang={{ lang() }}"><span class="glyphicon glyphicon-book"></span> {{ _('help') }}</a></li>
 {% if loggedin %}
-          <li><a href="{{ url_for('logout') }}"><span class="glyphicon glyphicon-log-out"></span> {{ _('logout') }}</a></li>
+          <li><a href="{{ url_for('logout') }}"><span class="glyphicon glyphicon-log-out"></span> {{ _('logout') }} <bdi>({{ username }})</bdi></a></li>
 {% endif %}
         </ul>
     </div>


### PR DESCRIPTION
## Description

Resolves #100

This patch simply adds the logged in user's username to the logout link when logged in. This is useful so users with multiple accounts like WMF-ers know what account they're using with video2commons at a glance.

## Screenshots

<img width="259" height="138" alt="Screenshot 2026-03-05 at 4 28 38 PM" src="https://github.com/user-attachments/assets/d6dd277b-e000-493a-9cf3-19a60bb890f9" />