### PR TITLE
Make session cookies persist the same as the Redis TTL

### DIFF
--- a/video2commons/frontend/app.py
+++ b/video2commons/frontend/app.py
@@ -22,12 +22,15 @@
 import json
 import logging
 import traceback
+
+from datetime import timedelta
 from urllib.parse import urlparse, urljoin
+
+import requests
 
 from flask import Flask, request, Response, session, render_template, redirect, url_for
 from mwoauth import AccessToken, ConsumerToken, RequestToken, Handshaker
 from requests_oauthlib import OAuth1
-import requests
 
 from video2commons.config import (
     consumer_key,
@@ -59,6 +62,7 @@ app.logger.setLevel(logging.INFO)
 app.session_cookie_name = "v2c-session"
 app.session_interface = RedisSessionInterface(redisconnection)
 
+app.permanent_session_lifetime = timedelta(days=1)
 app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 3600
 
 config_p = {
@@ -195,6 +199,7 @@ def querylanguage(auth):
 def loginredirect():
     """Initialize OAuth login."""
     app.session_interface.abandon_session(app, session)
+    session.permanent = True
 
     redirecturl, request_token = handshaker.initiate()
     session["request_token_key"], session["request_token_secret"] = (


### PR DESCRIPTION
## Description

Relevant Ticket: https://github.com/toolforge/video2commons/issues/316

This patch attempts to fix the issue in the aforementioned bug.

Although video2commons has a 1 day TTL for sessions enforced in the Redis store, there is no expiration or max age on the cookie itself. This results in Chromium browsers treating it as an in-memory session cookie rather than a permanent one. Chromium will clear session cookies if either the browser is manually closed, if a tab is marked inactive due to memory exhaustion on the device, or the app is suspended by the OS (e.g. Android).

In my testing on Android I've found that Chromium will inconsistently clear session cookies without a max age when switching away from the browser to other applications (e.g. to my password manager) in the middle of the OAuth flow, and consistently when I manually close it while still keeping the tab open. I suspect the way session cookies are handled by mobile Chromium is the likely cause of the OAuth flow breaking.

This patch tries to mitigate the issue by setting an explicit expiration that matches the expiration that we currently use in the Redis store for session data already.

## Changes

* Set an expiration of 1 day on the v2c session cookie (same as Redis)
* Mark the cookie as "permanent" in Flask, though this is a bit of a misnomer as it still expires after 1 day
  * This is necessary because if left unset Flask will make the cookie a session cookie with an indefinite expiration that is entirely up to the browser to decide when it expires