### PR TITLE
Strip spaces after running sanitization rules

### DIFF
--- a/video2commons/frontend/urlextract.py
+++ b/video2commons/frontend/urlextract.py
@@ -504,7 +504,7 @@ def sanitize(filename):
     for rule in sanitationRules:
         filename = rule["pattern"].sub(rule["replace"], filename)
 
-    return filename
+    return filename.strip()
 
 
 def capitalize_first_letter(input_string):


### PR DESCRIPTION
## Description

Resolves #329

It's possible for the sanitization rule execution to result in titles with leading or trailing spaces. This happens when an emoji with a joiner such as flags or gendered symbols are at the end of the title.

Adding an additional .strip() call after running the rules fixes this.

## Changes

* Add `.strip()` to return value of the `sanitize()` function