### PR TITLE
Pull in optional yt-dlp dependencies such as ejs

### DIFF
--- a/video2commons/backend/requirements.txt
+++ b/video2commons/backend/requirements.txt
@@ -1,4 +1,4 @@
-yt-dlp
+yt-dlp[default]
 celery[redis]
 langcodes
 chardet

--- a/video2commons/frontend/requirements.txt
+++ b/video2commons/frontend/requirements.txt
@@ -1,3 +1,4 @@
+yt-dlp[default]
 flask
 guess_language-spirit
 mwoauth


### PR DESCRIPTION
## Description

This is needed to properly solve the YouTube JS challenges with the newest version of yt-dlp, which will be useful if YouTube decides to stop blocking us later...

Also, this change explicitly adds yt-dlp to the frontend requirements as it's used there too. I think yt-dlp was installed there manually in the past.

## Changes

* Add `yt-dlp[default]` dependency to both the flask app and the celery worker