### PR TITLE
Do not disallow question marks and other chars in URLs

### DIFF
--- a/video2commons/frontend/urlextract.py
+++ b/video2commons/frontend/urlextract.py
@@ -465,8 +465,8 @@ sanitationRules = [
         ),
         "replace": "",
     },
-    # everything that wasn't covered yet
-    {"pattern": re.compile(r"[|#+?:/\\\u0000-\u001f\u007f]"), "replace": "-"},
+    # Pipes and backslashes
+    {"pattern": re.compile(r"[|\\]"), "replace": "-"},
     # titleblacklist-custom-double-apostrophe
     {"pattern": re.compile(r"'{2,}"), "replace": '"'},
 ]


### PR DESCRIPTION
The title sanitization rules are too strict and disallow valid titles. It's possible these rules used to make sense, but the rules have since been changed. This patch isn't exhaustive and other rules may need to be amended.

The new pattern has been adjusted to:

* Allow '?' and '+' in the title as those are allowed on Commons
* No longer check '\u0000-\u001f' and '\u007f' as those are already covered by earlier rules and are redundant
* No longer check for '#', ':', and '/' as those are covered by other rules, though I'm unsure if those rules are even needed