### PR TITLE
Allow confirmed users to bypass the 50 edit restriction

### DIFF
--- a/video2commons/frontend/app.py
+++ b/video2commons/frontend/app.py
@@ -247,8 +247,7 @@ def logincallback():
     if not ((is_autoconfirmed and (is_contributor or is_maintainer)) or is_confirmed):
         return render_template(
             "error.min.html",
-            message=("You must be an autoconfirmed Commons user with at least 50 edits to use this tool. "
-                "You do not meet the requirements. To use this tool, please "
+            message = ("You do not meet the requirements. To use this tool, please "
                 '<a href="https://commons.wikimedia.org/wiki/Commons:Requests_for_rights#Confirmed">'
                 "apply to be a confirmed user</a>, clearly explaining why you need to use video2commons."
             ),

--- a/video2commons/frontend/app.py
+++ b/video2commons/frontend/app.py
@@ -240,14 +240,18 @@ def logincallback():
     is_contributor = identify["editcount"] >= 50
     is_maintainer = is_sudoer(identify["username"])
     is_autoconfirmed = "autoconfirmed" in identify["rights"]
-    is_confirmed = "confirmed" in identify["rights"]
 
-    # Only allow autoconfirmed users either with at least 50 edits, or
-    # confirmed users, or maintainer status to use this tool.
+    # In Commons 'confirmed' is a group that inherits from 'autoconfirmed', so
+    # as a result it doesn't have its own distinct right.
+    is_confirmed = "confirmed" in identify["groups"]
+
+    # Only allow autoconfirmed users with at least 50 edits, manually confirmed
+    # users, or users with maintainer status to use this tool.
     if not ((is_autoconfirmed and (is_contributor or is_maintainer)) or is_confirmed):
         return render_template(
             "error.min.html",
-            message = ("You do not meet the requirements. To use this tool, please "
+            html_message=(
+                "You do not meet the requirements. To use this tool, please "
                 '<a href="https://commons.wikimedia.org/wiki/Commons:Requests_for_rights#Confirmed">'
                 "apply to be a confirmed user</a>, clearly explaining why you need to use video2commons."
             ),

--- a/video2commons/frontend/app.py
+++ b/video2commons/frontend/app.py
@@ -247,9 +247,11 @@ def logincallback():
     if not ((is_autoconfirmed and (is_contributor or is_maintainer)) or is_confirmed):
         return render_template(
             "error.min.html",
-            message="You do not meet the requirements. To use this tool, "
-            "please apply to be a confirmed user at https://commons.wikimedia.org/wiki/Commons:Requests_for_rights#Confirmed , "
-            "explaining why you need to use video2commons.",
+            message=("You must be an autoconfirmed Commons user with at least 50 edits to use this tool. "
+                "You do not meet the requirements. To use this tool, please "
+                '<a href="https://commons.wikimedia.org/wiki/Commons:Requests_for_rights#Confirmed">'
+                "apply to be a confirmed user</a>, clearly explaining why you need to use video2commons."
+            ),
             loggedin=True,
             username=identify["username"],
         )

--- a/video2commons/frontend/app.py
+++ b/video2commons/frontend/app.py
@@ -240,14 +240,16 @@ def logincallback():
     is_contributor = identify["editcount"] >= 50
     is_maintainer = is_sudoer(identify["username"])
     is_autoconfirmed = "autoconfirmed" in identify["rights"]
+    is_confirmed = "confirmed" in identify["rights"]
 
-    # Only allow autoconfirmed users either with at least 50 edits or
-    # maintainer status to use this tool.
-    if not (is_autoconfirmed and (is_contributor or is_maintainer)):
+    # Only allow autoconfirmed users either with at least 50 edits, or
+    # confirmed users, or maintainer status to use this tool.
+    if not ((is_autoconfirmed and (is_contributor or is_maintainer)) or is_confirmed):
         return render_template(
             "error.min.html",
-            message="You must be an autoconfirmed Commons user "
-            "with at least 50 edits to use this tool.",
+            message="You do not meet the requirements. To use this tool, "
+            "please apply to be a confirmed user at https://commons.wikimedia.org/wiki/Commons:Requests_for_rights#Confirmed , "
+            "explaining why you need to use video2commons.",
             loggedin=True,
             username=identify["username"],
         )


### PR DESCRIPTION
## Description

Based on #370, this patch allows users with the `confirmed` group to access video2commons without having to satisfy the 50 edit restriction.

## Context

* https://commons.wikimedia.org/wiki/Commons:Village_pump/Proposals#c-RoyZuo-20260406210300-Video2commons_requirement_waiver
* https://commons.wikimedia.org/wiki/Commons_talk:Video2commons#Overriding_the_usage_requirements