### PR TITLE
more PeerTube license templates

### DIFF
--- a/video2commons/frontend/urlextract.py
+++ b/video2commons/frontend/urlextract.py
@@ -324,6 +324,9 @@ def _uploader(url, ie_key, title, info):
 
 
 def _license(url, ie_key, title, info):
+    """
+    License template for Commons file description.
+    """
     uploader = info.get("uploader")
     uploader_param = ""
     if uploader:
@@ -360,8 +363,11 @@ def _license(url, ie_key, title, info):
     elif ie_key == "PeerTube":
         return {
             "Attribution": "{{cc-by-4.0%s}}" % uploader_param,
+            "CC BY 4.0": "{{cc-by-4.0%s}}" % uploader_param,
             "Attribution - Share Alike": "{{cc-by-sa-4.0%s}}" % uploader_param,
+            "CC BY-SA 4.0": "{{cc-by-sa-4.0%s}}" % uploader_param,
             "Public Domain Dedication": "{{cc-zero}}",
+            "CC0 1.0": "{{cc-zero}}",
         }.get(info.get("license"), default)
 
     return default


### PR DESCRIPTION
some PeerTube instances will return license
names in short form, like "CC BY-SA 4.0",
and they can be mapped to the Common templates

examples: 

❯ curl --silent "https://tube.undernet.uy/api/v1/videos/85naWb7mqfAzxbxUivLCZ1" | jq .licence.label
"CC BY 4.0"

❯ curl --silent "https://tube.undernet.uy/api/v1/videos/geXphAFZfr6zCGH2XLN5xp" | jq .licence.label
"CC BY-SA 4.0"

