### PR TITLE
Publish task updates in the worker

### DIFF
--- a/video2commons/backend/worker.py
+++ b/video2commons/backend/worker.py
@@ -46,6 +46,7 @@ from video2commons.config import (
     consumer_secret,
 )
 from video2commons.shared.stats import update_task_stats
+from video2commons.shared.tasks import get_task_status, publish_notification
 
 logging.basicConfig(level=logging.INFO)
 
@@ -92,7 +93,31 @@ def get_worker_concurrency():
         return int(match.group(1))
 
 
-@app.task(bind=True, track_started=False, base=AbortableTask)
+class EncodingTask(AbortableTask):
+    """Custom task class that notifies users of task success and failure."""
+
+    def on_success(self, retval, task_id, args, kwargs):
+        task_id = self.request.id
+
+        publish_notification(
+            redisconnection,
+            "update",
+            {"taskid": task_id, "data": get_task_status(redisconnection, task_id)},
+        )
+        return super().on_success(retval, task_id, args, kwargs)
+
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        task_id = self.request.id
+
+        publish_notification(
+            redisconnection,
+            "update",
+            {"taskid": task_id, "data": get_task_status(redisconnection, task_id)},
+        )
+        return super().on_failure(exc, task_id, args, kwargs, einfo)
+
+
+@app.task(bind=True, track_started=False, base=EncodingTask)
 def main(
     self,
     url,
@@ -106,6 +131,8 @@ def main(
     oauth,
 ):
     """Main worker code."""
+    task_id = self.request.id
+
     # Get a lock to prevent double-running with same task ID
     lockkey = "tasklock:" + self.request.id
     if redisconnection.exists(lockkey):
@@ -148,6 +175,12 @@ def main(
         print("%d: %s" % (s.percent, s.text))
 
         self.update_state(state="PROGRESS", meta={"text": s.text, "percent": s.percent})
+
+        publish_notification(
+            redisconnection,
+            "update",
+            {"taskid": task_id, "data": get_task_status(redisconnection, task_id)},
+        )
 
     def errorcallback(text):
         raise TaskError(text)

--- a/video2commons/frontend/api.py
+++ b/video2commons/frontend/api.py
@@ -32,12 +32,10 @@ from video2commons.config import session_key
 
 from video2commons.backend import worker
 
-from video2commons.frontend.errors import normalize_error
 from video2commons.frontend.shared import (
     redisconnection,
     check_banned,
     generate_csrf_token,
-    redis_publish,
 )
 from video2commons.frontend.urlextract import (
     do_extract_url,
@@ -52,6 +50,7 @@ from video2commons.frontend.urlextract import (
 )
 from video2commons.frontend.upload import upload as _upload, status as _uploadstatus
 from video2commons.shared import stats
+from video2commons.shared.tasks import publish_notification, get_task_status
 
 # Adapted from: https://stackoverflow.com/a/19161373
 YOUTUBE_REGEX = (
@@ -140,7 +139,7 @@ def status():
     key, ids = get_tasks()
     values = []
     for id in ids:
-        values.append(_status(id))
+        values.append(get_task_status(redisconnection, id))
 
     values = [_f for _f in values if _f]
     rooms = [t["id"] for t in values] + [key]
@@ -152,99 +151,7 @@ def status():
 @api.route("/status-single")
 def status_single():
     """Get the status of one task."""
-    return jsonify(value=_status(request.args["task"]))
-
-
-def _status(id):
-    title = get_title_from_task(id)
-    if not title:
-        # task has been forgotten -- results should have been expired
-        return None
-
-    res = worker.main.AsyncResult(id)
-    task = {"id": id, "title": title, "hostname": get_hostname_from_task(id)}
-
-    try:
-        state = res.state
-    except:
-        task.update(
-            {
-                "status": "fail",
-                "text": "The status of the task could not be retrieved.",
-                "traceback": traceback.format_exc(),
-            }
-        )
-    else:
-        if state == "PENDING":
-            task.update(
-                {
-                    "status": "progress",
-                    "text": "Your task is pending...",
-                    "progress": -1,
-                }
-            )
-        elif state == "PROGRESS":
-            task.update(
-                {
-                    "status": "progress",
-                    "text": res.result["text"],
-                    "progress": res.result["percent"],
-                }
-            )
-        elif state == "SUCCESS":
-            if isinstance(res.result, (list, tuple)):
-                filename, wikifileurl = res.result
-                task.update({"status": "done", "url": wikifileurl, "text": filename})
-            elif isinstance(res.result, dict):
-                if res.result["type"] == "done":
-                    task.update(
-                        {
-                            "status": "done",
-                            "url": res.result["url"],
-                            "text": res.result["filename"],
-                        }
-                    )
-        elif state == "FAILURE":
-            e = res.result
-            text = format_exception(e) if e else res.traceback
-            normalized_error = (normalize_error(text) or {}) if text else {}
-
-            task.update(
-                {
-                    "status": "fail",
-                    "text": text,
-                    "i18n_key": normalized_error.get("i18n_key"),
-                    "i18n_urls": normalized_error.get("urls"),
-                    "reportable": normalized_error.get("reportable", False),
-                    "restartable": (
-                        not redisconnection.exists("restarted:" + id)
-                        and redisconnection.exists("params:" + id)
-                    ),
-                }
-            )
-        elif state == "RETRY":
-            task.update(
-                {
-                    "status": "progress",
-                    "text": "Your task is being rescheduled...",
-                    "progress": -1,
-                }
-            )
-        elif state == "ABORTED":
-            task.update({"status": "abort", "text": "Your task is being aborted..."})
-        else:
-            task.update(
-                {
-                    "status": "fail",
-                    "text": (
-                        "This task is in an unknown state. Please file an issue "
-                        "in GitHub: <a></a>"
-                    ),
-                    "url": "https://github.com/toolforge/video2commons/issues",
-                }
-            )
-
-    return task
+    return jsonify(value=get_task_status(redisconnection, request.args["task"]))
 
 
 def is_sudoer(username):
@@ -269,23 +176,6 @@ def get_stats():
     stats = redisconnection.get("stats")
 
     return json.loads(stats) if stats else None
-
-
-def get_title_from_task(id):
-    """Get task title from task ID."""
-    return redisconnection.get("titles:" + id)
-
-
-def get_hostname_from_task(id):
-    """Get the hostname of the worker processing a task from task ID."""
-    hostname = redisconnection.get("tasklock:" + id)
-
-    # Old tasks don't have a hostname as the value in tasklock and store the
-    # literal 'T' instead. Reinterpret these values as null.
-    if hostname == "T":
-        hostname = None
-
-    return hostname
 
 
 @api.route("/extracturl", methods=["POST"])
@@ -500,8 +390,14 @@ def run_task_internal(filename, params, queue):
     except Exception:
         pass  # We don't want to fail the API call if we can't update stats.
 
-    redis_publish("add", {"taskid": taskid, "user": session["username"]})
-    redis_publish("update", {"taskid": taskid, "data": _status(taskid)})
+    publish_notification(
+        redisconnection, "add", {"taskid": taskid, "user": session["username"]}
+    )
+    publish_notification(
+        redisconnection,
+        "update",
+        {"taskid": taskid, "data": get_task_status(redisconnection, taskid)},
+    )
 
     return taskid
 
@@ -528,7 +424,11 @@ def restart_task():
     newid = run_task_internal(filename, json.loads(params), HEAVY_QUEUE)
     redisconnection.set("restarted:" + id, newid)
 
-    redis_publish("update", {"taskid": id, "data": _status(id)})
+    publish_notification(
+        redisconnection,
+        "update",
+        {"taskid": id, "data": get_task_status(redisconnection, id)},
+    )
 
     return jsonify(restart="success", id=id, taskid=newid)
 
@@ -548,7 +448,7 @@ def remove_task():
     redisconnection.delete("params:" + id)
     redisconnection.delete("restarted:" + id)
 
-    redis_publish("remove", {"taskid": id})
+    publish_notification(redisconnection, "remove", {"taskid": id})
 
     return jsonify(remove="success", id=id)
 
@@ -564,7 +464,11 @@ def abort_task():
         )
     worker.main.AsyncResult(id).abort()
 
-    redis_publish("update", {"taskid": id, "data": _status(id)})
+    publish_notification(
+        redisconnection,
+        "update",
+        {"taskid": id, "data": get_task_status(redisconnection, id)},
+    )
 
     return jsonify(remove="success", id=id)
 

--- a/video2commons/frontend/shared.py
+++ b/video2commons/frontend/shared.py
@@ -19,7 +19,6 @@
 
 """video2commons web shared."""
 
-import json
 from uuid import uuid4
 
 from flask import session
@@ -40,7 +39,3 @@ def generate_csrf_token():
     if "_csrf_token" not in session:
         session["_csrf_token"] = str(uuid4())
     return session["_csrf_token"]
-
-
-def redis_publish(typ, data):
-    redisconnection.publish("v2cnotif:" + typ, json.dumps(data))

--- a/video2commons/shared/errors.py
+++ b/video2commons/shared/errors.py
@@ -105,3 +105,13 @@ def normalize_error(message: str) -> dict | None:
             return entry.copy()
 
     return None
+
+
+def format_exception(e):
+    """Format an exception to text."""
+    desc = str(e)[:7000]
+
+    if isinstance(e, AssertionError):
+        return desc
+    else:
+        return f"An exception occurred: {type(e).__name__}: {desc}"

--- a/video2commons/shared/tasks.py
+++ b/video2commons/shared/tasks.py
@@ -1,0 +1,139 @@
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>
+
+"""Helper functions for communicating with task websockets."""
+
+import json
+import traceback
+
+from video2commons.shared.errors import normalize_error, format_exception
+
+
+def get_task_hostname(conn, task_id):
+    """Get the hostname of the worker processing a task from task ID."""
+    hostname = conn.get("tasklock:" + task_id)
+
+    # Old tasks don't have a hostname as the value in tasklock and store the
+    # literal 'T' instead. Reinterpret these values as null.
+    if hostname == "T":
+        hostname = None
+
+    return hostname.decode() if isinstance(hostname, bytes) else hostname
+
+
+def get_task_title(conn, task_id):
+    """Get task title from task ID."""
+    title = conn.get("titles:" + task_id)
+
+    return title.decode() if isinstance(title, bytes) else title
+
+
+def get_task_status(conn, task_id):
+    """Retrieve the status of a specific task."""
+    # The Celery task class in the worker module needs to be imported
+    # dynamically to prevent a cyclic reference.
+    from video2commons.backend.worker import main
+
+    title = get_task_title(conn, task_id)
+    if not title:
+        return None  # Task has been forgotten and results should be expired
+
+    res = main.AsyncResult(task_id)
+    task = {"id": task_id, "title": title, "hostname": get_task_hostname(conn, task_id)}
+
+    try:
+        state = res.state
+    except:
+        task.update(
+            {
+                "status": "fail",
+                "text": "The status of the task could not be retrieved.",
+                "traceback": traceback.format_exc(),
+            }
+        )
+    else:
+        if state == "PENDING":
+            task.update(
+                {
+                    "status": "progress",
+                    "text": "Your task is pending...",
+                    "progress": -1,
+                }
+            )
+        elif state == "PROGRESS":
+            task.update(
+                {
+                    "status": "progress",
+                    "text": res.result["text"],
+                    "progress": res.result["percent"],
+                }
+            )
+        elif state == "SUCCESS":
+            if isinstance(res.result, (list, tuple)):
+                filename, wikifileurl = res.result
+                task.update({"status": "done", "url": wikifileurl, "text": filename})
+            elif isinstance(res.result, dict):
+                if res.result["type"] == "done":
+                    task.update(
+                        {
+                            "status": "done",
+                            "url": res.result["url"],
+                            "text": res.result["filename"],
+                        }
+                    )
+        elif state == "FAILURE":
+            e = res.result
+            text = format_exception(e) if e else res.traceback
+            normalized_error = (normalize_error(text) or {}) if text else {}
+
+            task.update(
+                {
+                    "status": "fail",
+                    "text": text,
+                    "i18n_key": normalized_error.get("i18n_key"),
+                    "i18n_urls": normalized_error.get("urls"),
+                    "reportable": normalized_error.get("reportable", False),
+                    "restartable": (
+                        not conn.exists("restarted:" + task_id)
+                        and conn.exists("params:" + task_id)
+                    ),
+                }
+            )
+        elif state == "RETRY":
+            task.update(
+                {
+                    "status": "progress",
+                    "text": "Your task is being rescheduled...",
+                    "progress": -1,
+                }
+            )
+        elif state == "ABORTED":
+            task.update({"status": "abort", "text": "Your task is being aborted..."})
+        else:
+            task.update(
+                {
+                    "status": "fail",
+                    "text": (
+                        "This task is in an unknown state. Please file an issue "
+                        "in GitHub: <a></a>"
+                    ),
+                    "url": "https://github.com/toolforge/video2commons/issues",
+                }
+            )
+
+    return task
+
+
+def publish_notification(conn, ntype, data):
+    """Publish a task change notification."""
+    conn.publish("v2cnotif:" + ntype, json.dumps(data))

--- a/video2commons/shared/tasks.py
+++ b/video2commons/shared/tasks.py
@@ -53,7 +53,7 @@ def get_task_status(conn, task_id):
 
     try:
         state = res.state
-    except:
+    except Exception:
         task.update(
             {
                 "status": "fail",


### PR DESCRIPTION
## Description

When we switched over to using the websocket instead of polling the API for status, task updates stopped coming in. It turns out the worker was never updated to publish task updates, only the API was.

This patch moves the notification logic from `api.py` into a shared module that is used by both the API and the worker, allowing both to publish task notifications.

## Changes

- Create subclass of `AbortableTask` called `EncodingTask` that publishes task updates to Redis on success/failure.
- The worker now pushes task updates to Redis when the task percentage increases or a new message is sent.
- Moved helpers for pushing task messages in `api.py` to the `shared` module so it can be used in both the worker and API code, as the API also sends task messages to Redis.